### PR TITLE
fix: Add cache busting for data files

### DIFF
--- a/site.js
+++ b/site.js
@@ -10,10 +10,11 @@ document.addEventListener('DOMContentLoaded', () => {
   let allProducts = [];
 
   // Fetch all necessary data
+  const ts = new Date().getTime();
   Promise.all([
-    fetch('data/products.json').then(res => res.json()),
-    fetch('data/hero.json').then(res => res.json()),
-    fetch('data/inspiration.json').then(res => res.json())
+    fetch(`data/products.json?v=${ts}`).then(res => res.json()),
+    fetch(`data/hero.json?v=${ts}`).then(res => res.json()),
+    fetch(`data/inspiration.json?v=${ts}`).then(res => res.json())
   ])
   .then(([productsData, heroData, inspirationData]) => {
     allProducts = Object.values(productsData || {});


### PR DESCRIPTION
The front page was not updating with new images changed in the admin panel. This was due to browser caching of the data files (`hero.json`, `products.json`, `inspiration.json`).

This change adds a cache-busting query parameter (a timestamp) to the `fetch` calls in `site.js`. This ensures that the browser always downloads the latest version of the data files, resolving the issue.