### PR TITLE
feat: Adjust hero image size on mobile

### DIFF
--- a/site.css
+++ b/site.css
@@ -192,6 +192,11 @@ html,body{background:var(--bg)!important}
   .slideshow-nav.next {
     right: 10px;
   }
+
+  .hero-card {
+    aspect-ratio: 3/4;
+    max-height: 60vh;
+  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
The hero image was being cropped into a square on all screen sizes, which was not ideal for mobile devices.

This change adjusts the CSS to give the hero image a 3/4 aspect ratio on screens smaller than 768px. A `max-height` of `60vh` is also added to prevent the image from becoming too tall on certain devices. This makes the hero image look better on mobile phones.