### PR TITLE
fix(server): Bind Express server to 0.0.0.0

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -153,6 +153,6 @@ app.get('/', (req, res) => {
 });
 
 
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
The server was failing to respond to POST requests on Render, resulting in a 404 error for the login functionality.

This change explicitly binds the Express server to the host '0.0.0.0'. In containerized environments like Render, a server must listen on all network interfaces (0.0.0.0) to be accessible from the platform's proxy, which forwards public traffic to the container.

While Express often defaults to this, explicitly setting it prevents potential issues where the server might otherwise bind to localhost (127.0.0.1) and be unreachable from outside the container. This change ensures the server is correctly exposed to incoming traffic on Render.