### PR TITLE
fix: Correct admin login API endpoint URL

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -62,7 +62,7 @@ async function handleLogin() {
     loginError.textContent = '';
 
     try {
-        const response = await fetch(`${SYNC_BASE}/api/login`, {
+        const response = await fetch(`${SYNC_BASE}/api/auth/login`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username, password }),


### PR DESCRIPTION
The frontend was making a request to the wrong login URL, causing a 404 error on the live site. This change updates the fetch call in admin.js to use the correct /api/auth/login endpoint.