### PR TITLE
feat: Replace backend login with client-side obfuscated password

### DIFF
--- a/login.js
+++ b/login.js
@@ -3,21 +3,43 @@ function $(id) {
   return document.getElementById(id);
 }
 
-// The base URL for the backend API, same as in admin.js
-const SYNC_BASE = "https://hobbybyrox-site.onrender.com";
+// --- Obfuscation ---
+// This section contains the obfuscated password and the logic to reveal it.
+// The actual password is "RoxLovesHobby".
+
+// To change the password:
+// 1. Open the developer console in your browser (usually F12).
+// 2. Paste the following function and press Enter:
+/*
+function transformPassword(password) {
+  let transformed = '';
+  for (let i = 0; i < password.length; i++) {
+    transformed += String.fromCharCode(password.charCodeAt(i) + (i % 2 === 0 ? 1 : -1));
+  }
+  return transformed;
+}
+*/
+// 3. Run `transformPassword("YourNewPassword")` in the console.
+// 4. Copy the resulting string and replace the value of OBFUSCATED_PASS below.
+
+const OBFUSCATED_PASS = "SnyKpufrIncaz"; // This is "RoxLovesHobby" transformed
+
+function revealPassword(obfuscated) {
+  let original = '';
+  for (let i = 0; i < obfuscated.length; i++) {
+    original += String.fromCharCode(obfuscated.charCodeAt(i) - (i % 2 === 0 ? 1 : -1));
+  }
+  return original;
+}
+// --- End of Obfuscation ---
 
 async function handleLogin() {
-  // --- CHANGE STARTS HERE ---
-  // Get the values from BOTH input fields using their IDs.
-  const username = $('loginIn').value; // Make sure your username input has id="loginIn"
-  const password = $('password').value; // Make sure your password input has id="password"
-  // --- CHANGE ENDS HERE ---
-
+  const password = $('password').value;
   const loginError = $('loginError');
   const loginBtn = $('loginBtn');
 
-  if (!username || !password) {
-    loginError.textContent = 'Please enter a username and password.';
+  if (!password) {
+    loginError.textContent = 'Please enter a password.';
     return;
   }
 
@@ -25,31 +47,22 @@ async function handleLogin() {
   loginBtn.textContent = 'Logging in...';
   loginError.textContent = '';
 
-  try {
-    const response = await fetch(`${SYNC_BASE}/api/auth/login`, { // Also corrected the URL to /api/auth/login
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      // --- CHANGE STARTS HERE ---
-      // Use the 'username' variable defined above.
-      body: JSON.stringify({ username: username, password: password }),
-      // --- CHANGE ENDS HERE ---
-    });
+  // De-obfuscate the stored password and compare it to the user's input
+  const correctPassword = revealPassword(OBFUSCATED_PASS);
 
-    const result = await response.json();
-
-    if (response.ok) {
-      sessionStorage.setItem('admin_token', result.token);
+  // Simple delay to make it feel like a real login process
+  setTimeout(() => {
+    if (password === correctPassword) {
+      // On success, set a simple token and redirect to the admin page.
+      sessionStorage.setItem('admin_token', 'true');
       window.location.href = 'admin.html';
     } else {
-      loginError.textContent = result.message || 'Login failed. Please check your credentials.';
+      // On failure, show an error message.
+      loginError.textContent = 'Login failed. Please check your password.';
+      loginBtn.disabled = false;
+      loginBtn.textContent = 'Login';
     }
-  } catch (error) {
-    loginError.textContent = 'An error occurred. Please try again.';
-    console.error('Login error:', error);
-  } finally {
-    loginBtn.disabled = false;
-    loginBtn.textContent = 'Login';
-  }
+  }, 250); // 250ms delay
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -60,13 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   $('loginBtn').addEventListener('click', handleLogin);
 
-  // Allow pressing Enter in either field to submit
-  $('loginIn').addEventListener('keyup', (event) => {
-    if (event.key === 'Enter') {
-      handleLogin();
-    }
-  });
-
+  // Allow pressing Enter in the password field to submit
   $('password').addEventListener('keyup', (event) => {
     if (event.key === 'Enter') {
       handleLogin();


### PR DESCRIPTION
Refactored the login process to remove the dependency on the backend authentication server.

The new implementation uses a client-side only password check:
- The password is obfuscated and stored directly in `login.js`.
- A `revealPassword` function de-obfuscates the password for comparison against user input.
- Removed the buggy logic that tried to access a non-existent username field.
- Upon successful login, a simple session token is set to grant access to the admin panel.